### PR TITLE
Ecs-1

### DIFF
--- a/.github/workflows/merge_to_main_CI.yml
+++ b/.github/workflows/merge_to_main_CI.yml
@@ -19,4 +19,4 @@ jobs:
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose -- --test-threads 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,6 @@
-[package]
-name = "gear"
-version = "0.1.0"
-edition = "2018"
+[workspace]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+members = [
+    "src",
+    "component_macro"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,3 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "*"
-once_cell = "1.8.0"
-generic_static = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,11 +3,9 @@ name = "gear"
 version = "0.1.0"
 edition = "2018"
 
-[[test]]
-name = "test"
-path = "src/tests.rs"
-
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+rand = "*"
+once_cell = "1.8.0"
+generic_static = "*"

--- a/component_macro/Cargo.toml
+++ b/component_macro/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "component_macro"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "1.0"
+quote = "1.0"

--- a/component_macro/src/lib.rs
+++ b/component_macro/src/lib.rs
@@ -1,0 +1,30 @@
+extern crate proc_macro;
+
+use proc_macro::TokenStream;
+use quote::quote;
+use syn;
+
+#[proc_macro_derive(Component)]
+pub fn component_macro_derive(input: TokenStream) -> TokenStream {
+    // Construct a representation of Rust code as a syntax tree
+    // that we can manipulate
+    let ast = syn::parse(input).unwrap();
+
+    // Build the trait implementation
+    impl_component_macro(&ast)
+}
+
+fn impl_component_macro(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+    let gen = quote! {
+        impl Component for #name {
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+            fn as_mut_any(&mut self) -> &mut dyn Any {
+                self
+            }
+        }
+    };
+    gen.into()
+}

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gear"
+version = "0.1.0"
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+path = "./lib.rs"
+
+[dependencies]
+component_macro = { path = "../component_macro" }

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -9,4 +9,5 @@ edition = "2018"
 path = "./lib.rs"
 
 [dependencies]
+lazy_static = "1.4.0"
 component_macro = { path = "../component_macro" }

--- a/src/ecs/component.rs
+++ b/src/ecs/component.rs
@@ -1,0 +1,9 @@
+
+use std::any::Any;
+pub trait Component{
+    fn as_any(&self) -> &dyn Any;
+    fn as_mut_any(&mut self) -> &mut dyn Any;
+}
+
+
+

--- a/src/ecs/component.rs
+++ b/src/ecs/component.rs
@@ -1,4 +1,6 @@
 
+extern crate component_macro;
+pub use component_macro::Component;
 use std::any::Any;
 pub trait Component{
     fn as_any(&self) -> &dyn Any;

--- a/src/ecs/entity.rs
+++ b/src/ecs/entity.rs
@@ -1,30 +1,16 @@
-use super::{ComponentTypeId, EntityId};
+use super::EntityId;
 
 
 #[derive(Hash, Debug)]
 pub struct Entity{
     id : EntityId,
-    components: Vec<ComponentTypeId>,
 }
 impl Entity{
     pub fn new(id: EntityId,) -> Entity{
         Entity{
-            components: Vec::new(),
             id
         }
     }
-    // pub fn id(&self) -> EntityId{
-    //     self.id
-    // }
-    // pub fn components(&self) -> &Vec<ComponentTypeId>{
-    //     &self.components
-    // }
-    pub fn add_component(&mut self, component_id : ComponentTypeId){
-        self.components.push(component_id);
-    }
-    // pub fn get_component_by_id(&self) -> (){
-
-    // }
 }
 impl PartialEq for Entity{
     fn eq(&self, other: &Self) -> bool {

--- a/src/ecs/entity.rs
+++ b/src/ecs/entity.rs
@@ -1,0 +1,34 @@
+use super::{ComponentTypeId, EntityId};
+
+
+#[derive(Hash, Debug)]
+pub struct Entity{
+    id : EntityId,
+    components: Vec<ComponentTypeId>,
+}
+impl Entity{
+    pub fn new(id: EntityId,) -> Entity{
+        Entity{
+            components: Vec::new(),
+            id
+        }
+    }
+    // pub fn id(&self) -> EntityId{
+    //     self.id
+    // }
+    // pub fn components(&self) -> &Vec<ComponentTypeId>{
+    //     &self.components
+    // }
+    pub fn add_component(&mut self, component_id : ComponentTypeId){
+        self.components.push(component_id);
+    }
+    // pub fn get_component_by_id(&self) -> (){
+
+    // }
+}
+impl PartialEq for Entity{
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+impl Eq for Entity{}

--- a/src/ecs/entity_manager.rs
+++ b/src/ecs/entity_manager.rs
@@ -87,17 +87,17 @@ impl EntityManager{
     pub fn assign<T: 'static + Send + Component + Default>(&mut self, entity_id: EntityId) -> Result<&mut dyn Component, String>{
         let component_type_id = self.get_component_type_id::<T>();
 
-        match self.component_pools
+        let component_pool =  self.component_pools
             .entry(component_type_id)
-            .or_insert_with(HashMap::new)
-            .entry(entity_id){
+            .or_insert_with(HashMap::new);
+
+        match component_pool.entry(entity_id){
+            
                 Entry::Occupied(_) => 
                     Err(format!("Component {} already exists for entity {}", type_name::<T>(), entity_id)),
-                Entry::Vacant(_) => {
-                    self.component_pools
-                        .entry(component_type_id)
-                        .or_insert_with(HashMap::new)
-                        .insert(entity_id,Box::new(T::default()));  
+
+                Entry::Vacant(entry) => {
+                    entry.insert(Box::new(T::default()));  
                     Ok(self.get_component::<T>(entity_id).unwrap())
             },   
         }

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -1,10 +1,11 @@
+extern crate lazy_static;
 mod tests;
 pub mod entity;
-pub mod scene;
+pub mod entity_manager;
 pub mod component;
 pub use self::component::Component;
 pub use self::entity::Entity;
 pub use std::{collections::HashMap, error::Error};
-pub type EntityId = i64;
-pub type ComponentTypeId = i64;
-pub type ComponentPool = HashMap<EntityId, Box<dyn Component>>;
+pub type EntityId = u64;
+pub type ComponentTypeId = u64;
+pub type ComponentPool = HashMap<EntityId, Box<dyn Component + Send>>;

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -1,0 +1,10 @@
+mod tests;
+pub mod entity;
+pub mod scene;
+pub mod component;
+pub use self::component::Component;
+pub use self::entity::Entity;
+pub use std::{collections::HashMap, error::Error};
+pub type EntityId = i64;
+pub type ComponentTypeId = i64;
+pub type ComponentPool = HashMap<EntityId, Box<dyn Component>>;

--- a/src/ecs/scene.rs
+++ b/src/ecs/scene.rs
@@ -1,0 +1,82 @@
+use once_cell::sync::OnceCell;
+use generic_static::StaticTypeMap;
+use super::{Component, Entity, EntityId, ComponentPool, ComponentTypeId, HashMap};
+
+pub struct Scene{
+    component_type_counter : i64,
+    entity_id_counter : i64,
+    entities : Vec<Entity>,
+    component_pools : HashMap<ComponentTypeId, ComponentPool>,
+}
+impl Scene{
+    pub fn new() -> Self{
+        Scene{
+            component_type_counter : 0,
+            entity_id_counter : 0,
+            entities : Vec::new(),
+            component_pools : HashMap::new(),
+        }
+    }
+    pub fn create_entity(&mut self) -> EntityId{
+        let id = self.entity_id_counter;
+        self.entity_id_counter += 1;  
+        self.entities.push(Entity::new(id));
+        id
+    }
+
+    pub fn get_component_type_id<T: 'static>(&mut self) -> ComponentTypeId{ // T is bound to 'static
+        static GENERATE_ID: OnceCell<StaticTypeMap<i64>> = OnceCell::new();
+        let type_map = GENERATE_ID.get_or_init(|| StaticTypeMap::new());
+
+        *type_map.call_once::<T, _>(||{
+            self.component_type_counter += 1;
+            self.component_type_counter
+        })
+    }
+
+    pub fn get_component_pool<T: 'static>(&mut self) -> Result<&ComponentPool, &str>{
+        let component_type_id = self.get_component_type_id::<T>();
+        match self.component_pools.get(&component_type_id){
+            Some(pool) => Ok(pool),
+            None => Err("Pool does not exist for this component"),
+        }    
+    }
+
+    //TODO implement remove component
+
+    pub fn get_component<T: 'static + Component>(&mut self, entity_id: EntityId) -> Result<&mut dyn Component, String>{
+        let component_id = &self.get_component_type_id::<T>();
+
+        let component_pool = self.component_pools.get_mut(component_id);
+        match component_pool{
+            Some(pool) => {
+                match pool.get_mut(&entity_id){
+                    Some(component) => Ok(&mut **component),
+                    None => {
+                        let error_msg = 
+                            format!("The entity with ID {} does not own this component!", entity_id);
+                        Err(error_msg) 
+                    }
+                }    
+            }
+            None => {
+                let error_msg = 
+                    format!("The component does not exist in this scene!");
+                Err(error_msg)
+            }
+        }
+    }
+
+    pub fn assign<T: 'static +  Component + Default>(&mut self, entity_id: EntityId) -> (){
+        let component_type_id = self.get_component_type_id::<T>();
+    
+        self.component_pools
+            .entry(component_type_id)
+            .or_insert_with(HashMap::new)
+            .insert(entity_id,Box::new(T::default()));  
+        
+        let mut entity = Entity::new(entity_id);
+        entity.add_component(component_type_id);
+        self.entities.push(entity);
+    }
+}

--- a/src/ecs/scene.rs
+++ b/src/ecs/scene.rs
@@ -45,8 +45,6 @@ impl Scene{
         }    
     }
 
-    //TODO implement remove component
-
     pub fn get_component<T: Component>(&mut self, entity_id: EntityId) -> Result<&mut dyn Component, String>{
         let component_id = &self.get_component_type_id::<T>();
 
@@ -68,6 +66,11 @@ impl Scene{
                 Err(error_msg)
             }
         }
+    }
+
+    //TODO implement remove component
+    pub fn remove<T: 'static + Component>(&mut self, _entity_id: EntityId) -> Result<(), String>{
+        todo!();
     }
 
     pub fn assign<T: 'static + Component + Default>(&mut self, entity_id: EntityId) -> Result<&mut dyn Component, String>{

--- a/src/ecs/scene.rs
+++ b/src/ecs/scene.rs
@@ -1,11 +1,12 @@
-use once_cell::sync::OnceCell;
-use generic_static::StaticTypeMap;
+use std::{any::type_name, collections::hash_map::Entry};
+
 use super::{Component, Entity, EntityId, ComponentPool, ComponentTypeId, HashMap};
 
 pub struct Scene{
     component_type_counter : i64,
     entity_id_counter : i64,
     entities : Vec<Entity>,
+    component_name_to_type_id : HashMap<String, ComponentTypeId>,
     component_pools : HashMap<ComponentTypeId, ComponentPool>,
 }
 impl Scene{
@@ -14,6 +15,7 @@ impl Scene{
             component_type_counter : 0,
             entity_id_counter : 0,
             entities : Vec::new(),
+            component_name_to_type_id : HashMap::new(),
             component_pools : HashMap::new(),
         }
     }
@@ -23,28 +25,29 @@ impl Scene{
         self.entities.push(Entity::new(id));
         id
     }
-
-    pub fn get_component_type_id<T: 'static>(&mut self) -> ComponentTypeId{ // T is bound to 'static
-        static GENERATE_ID: OnceCell<StaticTypeMap<i64>> = OnceCell::new();
-        let type_map = GENERATE_ID.get_or_init(|| StaticTypeMap::new());
-
-        *type_map.call_once::<T, _>(||{
-            self.component_type_counter += 1;
-            self.component_type_counter
-        })
+    pub fn get_component_type_id<T>(&mut self) -> ComponentTypeId{
+        match self.component_name_to_type_id.get(type_name::<T>()){
+            Some(component_id) => *component_id,
+            None => {
+                let component_id = self.component_type_counter;
+                self.component_name_to_type_id.insert(String::from(type_name::<T>()), component_id);
+                self.component_type_counter += 1;
+                component_id
+            }
+        }         
     }
 
-    pub fn get_component_pool<T: 'static>(&mut self) -> Result<&ComponentPool, &str>{
-        let component_type_id = self.get_component_type_id::<T>();
-        match self.component_pools.get(&component_type_id){
-            Some(pool) => Ok(pool),
-            None => Err("Pool does not exist for this component"),
+    pub fn get_component_pool_size<T>(&mut self) -> Result<usize, String>{
+        let component_type_id = &self.get_component_type_id::<T>();
+        match self.component_pools.get(component_type_id){
+            Some(pool) => Ok(pool.len()),
+            None => Err(String::from("Pool does not exist for this component")),
         }    
     }
 
     //TODO implement remove component
 
-    pub fn get_component<T: 'static + Component>(&mut self, entity_id: EntityId) -> Result<&mut dyn Component, String>{
+    pub fn get_component<T: Component>(&mut self, entity_id: EntityId) -> Result<&mut dyn Component, String>{
         let component_id = &self.get_component_type_id::<T>();
 
         let component_pool = self.component_pools.get_mut(component_id);
@@ -67,16 +70,22 @@ impl Scene{
         }
     }
 
-    pub fn assign<T: 'static +  Component + Default>(&mut self, entity_id: EntityId) -> (){
+    pub fn assign<T: 'static + Component + Default>(&mut self, entity_id: EntityId) -> Result<&mut dyn Component, String>{
         let component_type_id = self.get_component_type_id::<T>();
-    
-        self.component_pools
+
+        match self.component_pools
             .entry(component_type_id)
             .or_insert_with(HashMap::new)
-            .insert(entity_id,Box::new(T::default()));  
-        
-        let mut entity = Entity::new(entity_id);
-        entity.add_component(component_type_id);
-        self.entities.push(entity);
+            .entry(entity_id){
+                Entry::Occupied(_) => 
+                    Err(format!("Component {} already exists for entity {}", type_name::<T>(), entity_id)),
+                Entry::Vacant(_) => {
+                    self.component_pools
+                        .entry(component_type_id)
+                        .or_insert_with(HashMap::new)
+                        .insert(entity_id,Box::new(T::default()));  
+                    Ok(self.get_component::<T>(entity_id).unwrap())
+            },   
+        }
     }
 }

--- a/src/ecs/tests/component_test.rs
+++ b/src/ecs/tests/component_test.rs
@@ -119,4 +119,13 @@ mod tests {
 
         assert_eq!(pool_size, 3);
     }
+
+    #[test]
+    #[should_panic(expected = "not yet implemented")]
+    fn remove_component_test(){
+        let mut scene = Scene::new();
+        let ent1 = scene.create_entity();
+        scene.assign::<Transform>(ent1).expect("0");
+        scene.remove::<Transform>(ent1).unwrap(); // Should panic here
+    }
 }

--- a/src/ecs/tests/component_test.rs
+++ b/src/ecs/tests/component_test.rs
@@ -3,32 +3,17 @@ mod tests {
     use std::any::Any;
     use crate::ecs::scene::Scene;
     use crate::math_engine::Vector3;
+    use crate::ecs::Component;
 
-    #[derive(Default)]
+    #[derive(Default, Component)]
     struct Shape {
         #[allow(dead_code)]
         vec3 : Vector3
     }
-    impl Component for Shape{
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-        fn as_mut_any(&mut self) -> &mut dyn Any {
-            self
-        }
-    }
-    #[derive(Default)]
+    #[derive(Default, Component)]
     struct Transform {
         #[allow(dead_code)]
         pub vec3 : Vector3
-    }
-    impl Component for Transform{
-        fn as_any(&self) -> &dyn Any {
-            self
-        }
-        fn as_mut_any(&mut self) -> &mut dyn Any {
-            self
-        }
     }
 
     #[test]
@@ -47,8 +32,6 @@ mod tests {
         assert_eq!(id5, id2);
         assert_eq!(id3, id4);
     }
-
-    use crate::ecs::Component;
 
     #[test]
     fn component_assign_test(){

--- a/src/ecs/tests/component_test.rs
+++ b/src/ecs/tests/component_test.rs
@@ -51,24 +51,17 @@ mod tests {
     use crate::ecs::Component;
 
     #[test]
-    fn entity_assign_test(){
+    fn component_assign_test(){
         let mut scene = Scene::new();
         let ent1 = scene.create_entity();
         let ent2 = scene.create_entity();
         let ent3 = scene.create_entity();
 
-        scene.assign::<Transform>(ent1);
-        scene.assign::<Transform>(ent2);
-        scene.assign::<Transform>(ent3);
-
-        //Check component pool size
-        // let pool_size = match scene.get_component_pool::<Transform>(){
-        //     Ok(pool) => pool.len(),
-        //     Err(err_msg) => panic!(err_msg),
-        // };
-        // assert_eq!(pool_size, 2);
+        scene.assign::<Transform>(ent1).unwrap();
+        scene.assign::<Transform>(ent2).unwrap();
+        scene.assign::<Transform>(ent3).unwrap();
     
-        scene.assign::<Shape>(ent3);
+        scene.assign::<Shape>(ent3).unwrap();
 
         match scene.get_component::<Transform>(ent1){
             Ok(component) => {
@@ -83,7 +76,7 @@ mod tests {
             Err(err_msg) => panic!("{}", err_msg)
         }
 
-        // Check that "Transform" component was modified:
+        // Check that "Transform" component was actually modified:
         match scene.get_component::<Transform>(ent1){
             Ok(component) => {
                 let transform: &Transform = match component.as_any().downcast_ref::<Transform>() {
@@ -111,5 +104,36 @@ mod tests {
             Ok(_) => panic!("ent1 shouldn't have \"Shape\" component"),
             Err(_) => ()
         }
+    }
+
+    #[test]
+    fn component_pool_size_test(){
+        let mut scene = Scene::new();
+        let ent1 = scene.create_entity();
+        let ent2 = scene.create_entity();
+        let ent3 = scene.create_entity();
+
+        match scene.get_component_pool_size::<Transform>(){
+            Ok(_) => panic!("Should be empty!"),
+            Err(_) => ()
+        };
+
+        scene.assign::<Transform>(ent1).expect("0");
+        let pool_size = match scene.get_component_pool_size::<Transform>(){
+            Ok(size) => size,
+            Err(err_msg) => panic!("{}", err_msg),
+        };
+
+        assert_eq!(pool_size, 1);
+
+        scene.assign::<Transform>(ent2).expect("1");
+        scene.assign::<Transform>(ent3).expect("2");
+
+        let pool_size = match scene.get_component_pool_size::<Transform>(){
+            Ok(size) => size,
+            Err(err_msg) => panic!("{}", err_msg),
+        };
+
+        assert_eq!(pool_size, 3);
     }
 }

--- a/src/ecs/tests/component_test.rs
+++ b/src/ecs/tests/component_test.rs
@@ -1,0 +1,115 @@
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+    use crate::ecs::scene::Scene;
+    use crate::math_engine::Vector3;
+
+    #[derive(Default)]
+    struct Shape {
+        #[allow(dead_code)]
+        vec3 : Vector3
+    }
+    impl Component for Shape{
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_mut_any(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+    #[derive(Default)]
+    struct Transform {
+        #[allow(dead_code)]
+        pub vec3 : Vector3
+    }
+    impl Component for Transform{
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+        fn as_mut_any(&mut self) -> &mut dyn Any {
+            self
+        }
+    }
+
+    #[test]
+    fn get_id_api_test(){
+        let mut scene = Scene::new();
+        let id1 = scene.get_component_type_id::<Transform>();
+        let id2 = scene.get_component_type_id::<Shape>();
+        let id3 = scene.get_component_type_id::<Transform>();
+        let id4 = scene.get_component_type_id::<Transform>();
+        let id5 = scene.get_component_type_id::<Shape>();
+        
+        assert_eq!(id1, id3);
+        assert_ne!(id1, id2);
+        assert_ne!(id3, id5);
+        assert_ne!(id5, id4);
+        assert_eq!(id5, id2);
+        assert_eq!(id3, id4);
+    }
+
+    use crate::ecs::Component;
+
+    #[test]
+    fn entity_assign_test(){
+        let mut scene = Scene::new();
+        let ent1 = scene.create_entity();
+        let ent2 = scene.create_entity();
+        let ent3 = scene.create_entity();
+
+        scene.assign::<Transform>(ent1);
+        scene.assign::<Transform>(ent2);
+        scene.assign::<Transform>(ent3);
+
+        //Check component pool size
+        // let pool_size = match scene.get_component_pool::<Transform>(){
+        //     Ok(pool) => pool.len(),
+        //     Err(err_msg) => panic!(err_msg),
+        // };
+        // assert_eq!(pool_size, 2);
+    
+        scene.assign::<Shape>(ent3);
+
+        match scene.get_component::<Transform>(ent1){
+            Ok(component) => {
+                let transform: &mut Transform = match component.as_mut_any().downcast_mut::<Transform>() {
+                    Some(transform) => transform,
+                    None => panic!("&component isn't a Transform!"),
+                };
+                transform.vec3.x = 6.;
+                transform.vec3.y = 0.;
+                transform.vec3.z = 8.;
+            }
+            Err(err_msg) => panic!("{}", err_msg)
+        }
+
+        // Check that "Transform" component was modified:
+        match scene.get_component::<Transform>(ent1){
+            Ok(component) => {
+                let transform: &Transform = match component.as_any().downcast_ref::<Transform>() {
+                    Some(transform) => transform,
+                    None => panic!("&component isn't a Transform!"),
+                };
+                assert_eq!(transform.vec3.magnitude(), 10.)
+            }
+            Err(err_msg) => panic!("{}", err_msg)
+        }
+
+        match scene.get_component::<Transform>(ent2){
+            Ok(_) => (),
+            Err(err_msg) => panic!("{}", err_msg)
+        }
+        match scene.get_component::<Transform>(ent3){
+            Ok(_) => (),
+            Err(err_msg) => panic!("{}", err_msg)
+        }
+        match scene.get_component::<Shape>(ent3){
+            Ok(_) => (),
+            Err(err_msg) => panic!("{}", err_msg)
+        }
+        match scene.get_component::<Shape>(ent1){
+            Ok(_) => panic!("ent1 shouldn't have \"Shape\" component"),
+            Err(_) => ()
+        }
+    }
+}

--- a/src/ecs/tests/mod.rs
+++ b/src/ecs/tests/mod.rs
@@ -1,0 +1,1 @@
+mod component_test;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod ecs;
+pub mod math_engine;
+
+
+
+

--- a/src/math_engine/matrices.rs
+++ b/src/math_engine/matrices.rs
@@ -1,3 +1,4 @@
+#[derive (Debug, PartialEq)]
 pub struct Matrix4{
     #[allow(dead_code)] // TODO: this is here only to silence compiler warnings, remove this later
     mat : [[f64; 4]; 4],

--- a/src/math_engine/mod.rs
+++ b/src/math_engine/mod.rs
@@ -1,5 +1,8 @@
+pub mod tests;
 mod matrices;
 mod vectors;
+pub use self::tests::matrix_test;
+pub use self::tests::vector_test;
 pub use self::matrices::Matrix4;
 pub use self::vectors::Vector3;
 pub use self::vectors::Vector2;

--- a/src/math_engine/tests/matrix_test.rs
+++ b/src/math_engine/tests/matrix_test.rs
@@ -1,21 +1,7 @@
-mod math_engine;
-
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use crate::math_engine::Matrix4;
-    use crate::math_engine::Vector3;
-    use crate::math_engine::Vector2;
     
-    #[test]
-    fn vector_magnitude_test(){
-        let vector3 = Vector3::new(8., 0., 6.);
-        assert_eq!(vector3.magnitude(), 10.);
-
-        let vector2 = Vector2::new(3., 4.);
-        assert_eq!(vector2.magnitude(), 5.);
-    }
-    
-
     /* This test calls a function that isn't implemented yet, and therefore it should panic. 
     However, the test should still pass due to #[should_panic] annotation. */
     #[test]
@@ -25,5 +11,3 @@ mod tests {
         matrix4.inverse();
     }
 }
-
-

--- a/src/math_engine/tests/mod.rs
+++ b/src/math_engine/tests/mod.rs
@@ -1,0 +1,2 @@
+pub mod vector_test;
+pub mod matrix_test;

--- a/src/math_engine/tests/vector_test.rs
+++ b/src/math_engine/tests/vector_test.rs
@@ -1,0 +1,14 @@
+#[cfg(test)]
+pub mod tests {
+    use crate::math_engine::Vector3;
+    use crate::math_engine::Vector2;
+    
+    #[test]
+    fn vector_magnitude_test(){
+        let vector3 = Vector3::new(8., 0., 6.);
+        assert_eq!(vector3.magnitude(), 10.);
+        
+        let vector2 = Vector2::new(3., 4.);
+        assert_eq!(vector2.magnitude(), 5.);
+    }
+}

--- a/src/math_engine/vectors.rs
+++ b/src/math_engine/vectors.rs
@@ -1,7 +1,8 @@
+#[derive (Debug, PartialEq, Default)]
 pub struct Vector3{
-    x : f64,
-    y : f64,
-    z : f64,
+    pub x : f64,
+    pub y : f64,
+    pub z : f64,
 }
 impl Vector3{
     pub fn new(x: f64, y: f64, z: f64) -> Vector3{
@@ -14,9 +15,10 @@ impl Vector3{
     }
 }
 
+#[derive (Debug, PartialEq, Default)]
 pub struct Vector2{
-    x : f64,
-    y : f64,
+    pub x : f64,
+    pub y : f64,
 }
 impl Vector2{
     pub fn new(x: f64, y: f64,) -> Vector2{


### PR DESCRIPTION
Details:
- Structs and traits:
  - Component - abstract trait (interface). Any object that wants to be a component needs to ```impl``` this trait.
  - Entity - an abstract object with a unique id. Components may be attached to an entity via scene API.
  - Scene - manager of entities and component pools (this is subject to change, I will open an issue regarding this matter soon). Provides API for attaching components to entities, and holds mappings between component types and their respective component pool. 
  Each member in a component pool consists of a specific component, and an entity ID to indicate which entity holds this component.
- Scene API:
  - Create entity.
  - Attach component to an entity.
  - Get attached component from an entity (as mutable and immutable).
  - Removing components and entities is **yet to be implemented**.
- Macros:
  - Created a #[derive Component] macro - if a struct wants to be a Component, we can simply add ```#[derive Component]``` above the struct's definition and it will automatically implement the component trait thanks to the macro.
  - Created a new crate for the macro definition, and changed the Cargo.toml file to hold a workspace made of 2 crates: gear and component_macro. 
  The reason for this was:  "When creating procedural macros, the definitions must reside in their own crate with a special crate type. This is for complex technical reasons that we hope to eliminate in the future." - _https://doc.rust-lang.org/book/ch19-06-macros.html_
- Tests:
  - Rearranged the tests - instead of having one single tests.rs file, created a folder of tests in each module and implemented module-specific tests in said folder.